### PR TITLE
fix(RRSIG): Reconstruct signed data per algorithm in RFC 4035

### DIFF
--- a/src/lib/dns/Record.spec.ts
+++ b/src/lib/dns/Record.spec.ts
@@ -215,6 +215,14 @@ describe('Record', () => {
       expect(ANSWER.decode(serialisation)).toHaveProperty('ttl', RECORD.ttl);
     });
 
+    test('Record TTL should be overridable', () => {
+      const differentTtl = RECORD.ttl + 1;
+
+      const serialisation = RECORD.serialise(differentTtl);
+
+      expect(ANSWER.decode(serialisation)).toHaveProperty('ttl', differentTtl);
+    });
+
     test('Record data should be serialised', () => {
       const serialisation = RECORD.serialise();
 

--- a/src/lib/dns/Record.ts
+++ b/src/lib/dns/Record.ts
@@ -50,7 +50,7 @@ export class Record {
     }
   }
 
-  public serialise(): Buffer {
+  public serialise(ttl: number | null = null): Buffer {
     const labelsSerialised = serialiseName(this.name);
 
     const typeSerialised = Buffer.allocUnsafe(2);
@@ -60,7 +60,7 @@ export class Record {
     classSerialised.writeUInt16BE(this.class_);
 
     const ttlSerialised = Buffer.allocUnsafe(4);
-    ttlSerialised.writeUInt32BE(this.ttl);
+    ttlSerialised.writeUInt32BE(ttl ?? this.ttl);
 
     const dataLengthSerialised = Buffer.allocUnsafe(2);
     dataLengthSerialised.writeUInt16BE(this.dataSerialised.length);

--- a/src/lib/dns/name.spec.ts
+++ b/src/lib/dns/name.spec.ts
@@ -1,7 +1,7 @@
 import { name as NAME } from '@leichtgewicht/dns-packet';
 
-import { RECORD } from '../../testUtils/dnsStubs';
-import { normaliseName, serialiseName } from './name';
+import { RECORD, RECORD_TLD } from '../../testUtils/dnsStubs';
+import { countLabels, normaliseName, serialiseName } from './name';
 
 describe('serialiseName', () => {
   const recordNameWithoutDot = RECORD.name.replace(/\.$/, '');
@@ -44,5 +44,23 @@ describe('normaliseName', () => {
     const name = '.';
 
     expect(normaliseName(name)).toEqual(name);
+  });
+});
+
+describe('countLabels', () => {
+  test('Root name should have zero labels', () => {
+    expect(countLabels('.')).toEqual(0);
+  });
+
+  test('TLD should have one label', () => {
+    expect(countLabels(RECORD_TLD)).toEqual(1);
+  });
+
+  test('Apex domain should have two labels', () => {
+    expect(countLabels(RECORD.name)).toEqual(2);
+  });
+
+  test('Wildcard should not count towards labels', () => {
+    expect(countLabels(`*.${RECORD.name}`)).toEqual(2);
   });
 });

--- a/src/lib/dns/name.ts
+++ b/src/lib/dns/name.ts
@@ -16,3 +16,12 @@ export function serialiseName(name: string): Buffer {
 export function normaliseName(name: string): string {
   return name.endsWith('.') ? name : `${name}.`;
 }
+
+export function countLabels(name: string): number {
+  const nameWithoutTrailingDot = name.replace(/\.$/, '');
+  if (nameWithoutTrailingDot === '') {
+    return 0;
+  }
+  const labels = nameWithoutTrailingDot.split('.').filter((label) => label !== '*');
+  return labels.length;
+}

--- a/src/lib/rdata/RrsigData.spec.ts
+++ b/src/lib/rdata/RrsigData.spec.ts
@@ -127,13 +127,6 @@ describe('RrsigData', () => {
       expect(data.verifyRrset(RRSET, signer.publicKey)).toBeFalse();
     });
 
-    test('Original TTL should match RRset TTL', () => {
-      const invalidRrset = RRSet.init(QUESTION, [RECORD.shallowCopy({ ttl: RECORD.ttl + 1 })]);
-      const { data } = signer.generateRrsig(invalidRrset, STUB_KEY_TAG, SIGNATURE_OPTIONS);
-
-      expect(data.verifyRrset(RRSET, signer.publicKey)).toBeFalse();
-    });
-
     describe('Label count', () => {
       test('RRset owner labels greater than RRSig count should be SECURE', async () => {
         const name = `subdomain.${RECORD.name}`;

--- a/src/lib/verification/SignedRRSet.spec.ts
+++ b/src/lib/verification/SignedRRSet.spec.ts
@@ -131,8 +131,13 @@ describe('SignedRRSet', () => {
     test('Verification should fail if not deemed valid by any RRSig', () => {
       const dnskey = signer.generateDnskey();
       const rrsig = signer.generateRrsig(RRSET, dnskey.data.calculateKeyTag(), RRSIG_OPTIONS);
-      const invalidRecords = RRSET.records.map((r) => r.shallowCopy({ ttl: r.ttl + 1 }));
-      const signedRrset = SignedRRSet.initFromRecords(QUESTION, [...invalidRecords, rrsig.record]);
+      const type = IANA_RR_TYPE_IDS.A;
+      expect(type).not.toEqual(RRSET.type); // Make sure we're picking something different indeed
+      const invalidRecords = RRSET.records.map((r) => r.shallowCopy({ type }));
+      const signedRrset = SignedRRSet.initFromRecords(QUESTION.shallowCopy({ type }), [
+        ...invalidRecords,
+        rrsig.record,
+      ]);
 
       expect(signedRrset.verify([dnskey], VALIDITY_PERIOD)).toBeFalse();
     });


### PR DESCRIPTION
[Section 5.3.2](https://www.rfc-editor.org/rfc/rfc4035#section-5.3.2).

- Use RRSIG's original TTL when reconstructing signed data, instead of the RRset's TTL.
- Use a label count of `0` when the name is the root (`.`). We were using `1`.
