### PR TITLE
fix(RRset): Fix canonical ordering per RFC 4034 (Section 6.3)

### DIFF
--- a/src/lib/dns/RRSet.ts
+++ b/src/lib/dns/RRSet.ts
@@ -59,14 +59,20 @@ export class RRSet {
  */
 function canonicallySortRecords(originalRecords: readonly Record[]): readonly Record[] {
   const recordSorted = [...originalRecords].sort((a, b) => {
-    const byteLengthDifference = a.dataSerialised.byteLength - b.dataSerialised.byteLength;
-    if (byteLengthDifference !== 0) {
-      return byteLengthDifference;
-    }
-
-    for (let index = 0; index < a.dataSerialised.byteLength; index++) {
+    const maxLength = Math.max(a.dataSerialised.byteLength, b.dataSerialised.byteLength);
+    for (let index = 0; index < maxLength; index++) {
       const aOctet = a.dataSerialised[index];
+      // istanbul ignore next
+      if (aOctet === undefined) {
+        return -1;
+      }
+
       const bOctet = b.dataSerialised[index];
+      // istanbul ignore next
+      if (bOctet === undefined) {
+        return 1;
+      }
+
       if (aOctet !== bOctet) {
         return aOctet - bOctet;
       }


### PR DESCRIPTION
Unfortunately, I couldn't find a way to test this as I'd have to craft RDATAs that would fail to be parsed by `dns-packet`, so I'm skipping the coverage for those lines.