### PR TITLE
fix: Avoid subsequent resolutions when one fails

### DIFF
--- a/src/lib/UnverifiedChain.spec.ts
+++ b/src/lib/UnverifiedChain.spec.ts
@@ -187,6 +187,15 @@ describe('retrieve', () => {
       rcode,
     );
   });
+
+  test('Retrieval should error out with the first resolution error', async () => {
+    const originalError = new Error('Whoops');
+    stubResolver.mockRejectedValueOnce(originalError);
+
+    await expect(UnverifiedChain.retrieve(QUESTION, stubResolver)).rejects.toBe(originalError);
+
+    expect(stubResolver).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('initFromMessages', () => {

--- a/src/lib/UnverifiedChain.ts
+++ b/src/lib/UnverifiedChain.ts
@@ -27,8 +27,9 @@ async function retrieveZoneMessages(
 ): Promise<MessageByKey> {
   const question = new Question('.', recordType, classType);
   return zoneNames.reduce(async (messages, zoneName) => {
+    const messageByKey = await messages;
     const message = await resolver(question.shallowCopy({ name: zoneName }));
-    return { ...(await messages), [`${zoneName}/${recordType}`]: message };
+    return { ...messageByKey, [`${zoneName}/${recordType}`]: message };
   }, Promise.resolve({} as MessageByKey));
 }
 


### PR DESCRIPTION
Needed in https://github.com/relaycorp/vera-js/pull/24
