### PR TITLE
feat: Output validity period

### DIFF
--- a/src/lib/DatePeriod.spec.ts
+++ b/src/lib/DatePeriod.spec.ts
@@ -92,3 +92,28 @@ describe('overlaps', () => {
     expect(period.overlaps(start, end)).toBeTrue();
   });
 });
+
+describe('intersect', () => {
+  const stubPeriod = DatePeriod.init(subSeconds(NOW, 1), addSeconds(NOW, 1));
+
+  test('Undefined should be returned if periods do not overlap', () => {
+    const otherPeriod = DatePeriod.init(
+      addSeconds(stubPeriod.end, 1),
+      addSeconds(stubPeriod.end, 2),
+    );
+
+    expect(stubPeriod.intersect(otherPeriod)).toBeUndefined();
+  });
+
+  test('Start and end dates should be latest and earliest of two periods, respectively', () => {
+    const otherPeriod = DatePeriod.init(
+      addSeconds(stubPeriod.start, 1),
+      addSeconds(stubPeriod.end, 1),
+    );
+
+    const intersection = stubPeriod.intersect(otherPeriod);
+
+    expect(intersection!.start).toStrictEqual(otherPeriod.start);
+    expect(intersection!.end).toStrictEqual(stubPeriod.end);
+  });
+});

--- a/src/lib/DatePeriod.ts
+++ b/src/lib/DatePeriod.ts
@@ -20,6 +20,15 @@ export class DatePeriod {
       return false;
     }
 
-    return this.end >= otherStart;
+    return otherStart <= this.end;
+  }
+
+  public intersect(otherPeriod: DatePeriod): DatePeriod | undefined {
+    if (!this.overlaps(otherPeriod.start, otherPeriod.end)) {
+      return undefined;
+    }
+    const start = this.start < otherPeriod.start ? otherPeriod.start : this.start;
+    const end = this.end < otherPeriod.end ? this.end : otherPeriod.end;
+    return new DatePeriod(start, end);
   }
 }

--- a/src/lib/DatedValue.ts
+++ b/src/lib/DatedValue.ts
@@ -1,0 +1,6 @@
+import { type DatePeriod } from './DatePeriod.js';
+
+export interface DatedValue<Value> {
+  readonly value: Value;
+  readonly datePeriods: readonly DatePeriod[];
+}

--- a/src/lib/SignedRrSet.ts
+++ b/src/lib/SignedRrSet.ts
@@ -59,13 +59,12 @@ export class SignedRrSet {
 
   protected filterRrsigs(
     dnsKeys: readonly DatedValue<DnskeyRecord>[],
-    datePeriod: DatePeriod,
     expectedSigner: string | undefined,
   ) {
     return this.rrsigs.reduce<readonly RrsigWithDnskeyData[]>((accumulator, rrsig) => {
       const matchingDnskeys = dnsKeys.filter(
         (dnskey) =>
-          dnskey.value.data.verifyRrsig(rrsig.data, datePeriod) &&
+          dnskey.value.data.verifyRrsig(rrsig.data, dnskey.datePeriods) &&
           (expectedSigner ?? dnskey.value.record.name) === rrsig.data.signerName,
       );
       const additionalItems = matchingDnskeys.map((dnskey) => ({
@@ -78,10 +77,9 @@ export class SignedRrSet {
 
   public verify(
     dnsKeys: readonly DatedValue<DnskeyRecord>[],
-    datePeriod: DatePeriod,
     expectedSigner?: string,
   ): readonly DatePeriod[] {
-    const eligibleRrsigs = this.filterRrsigs(dnsKeys, datePeriod, expectedSigner);
+    const eligibleRrsigs = this.filterRrsigs(dnsKeys, expectedSigner);
 
     const matchingRrsigs = eligibleRrsigs.filter(({ dnskey, rrsig }) =>
       rrsig.data.verifyRrset(this.rrset, dnskey.value.data.publicKey),

--- a/src/lib/records/DnskeyData.spec.ts
+++ b/src/lib/records/DnskeyData.spec.ts
@@ -157,14 +157,14 @@ describe('DnskeyData', () => {
         stubRrsigOptions,
       );
 
-      expect(dnskeyData.verifyRrsig(rrsigData, stubValidityPeriod)).toBeFalse();
+      expect(dnskeyData.verifyRrsig(rrsigData, [stubValidityPeriod])).toBeFalse();
     });
 
     test('Key tag should match', () => {
       const differentKeyTag = dnskeyData.calculateKeyTag() + 1;
       const { data: rrsigData } = tldSigner.generateRrsig(RRSET, differentKeyTag, stubRrsigOptions);
 
-      expect(dnskeyData.verifyRrsig(rrsigData, stubValidityPeriod)).toBeFalse();
+      expect(dnskeyData.verifyRrsig(rrsigData, [stubValidityPeriod])).toBeFalse();
     });
 
     test('Signature validity be within required period', () => {
@@ -173,17 +173,17 @@ describe('DnskeyData', () => {
         signatureInception: subSeconds(stubValidityPeriod.start, 2),
       });
 
-      expect(dnskeyData.verifyRrsig(rrsigData, stubValidityPeriod)).toBeFalse();
+      expect(dnskeyData.verifyRrsig(rrsigData, [stubValidityPeriod])).toBeFalse();
     });
 
-    test('Valid RRSIg should be SECURE', () => {
+    test('Valid RRSig should be reported as such', () => {
       const { data: rrsigData } = tldSigner.generateRrsig(
         RRSET,
         dnskeyData.calculateKeyTag(),
         stubRrsigOptions,
       );
 
-      expect(dnskeyData.verifyRrsig(rrsigData, stubValidityPeriod)).toBeTrue();
+      expect(dnskeyData.verifyRrsig(rrsigData, [stubValidityPeriod])).toBeTrue();
     });
   });
 });

--- a/src/lib/records/DnskeyData.ts
+++ b/src/lib/records/DnskeyData.ts
@@ -80,7 +80,7 @@ export class DnskeyData implements DnssecRecordData {
     return calculateKeyTag(rdata);
   }
 
-  public verifyRrsig(rrsigData: RrsigData, datePeriod: DatePeriod): boolean {
+  public verifyRrsig(rrsigData: RrsigData, datePeriods: readonly DatePeriod[]): boolean {
     if (this.calculateKeyTag() !== rrsigData.keyTag) {
       return false;
     }
@@ -89,6 +89,8 @@ export class DnskeyData implements DnssecRecordData {
       return false;
     }
 
-    return datePeriod.overlaps(rrsigData.signatureInception, rrsigData.signatureExpiry);
+    return datePeriods.some((period) =>
+      period.overlaps(rrsigData.signatureInception, rrsigData.signatureExpiry),
+    );
   }
 }

--- a/src/lib/testing/ZoneSigner.ts
+++ b/src/lib/testing/ZoneSigner.ts
@@ -33,13 +33,13 @@ interface RecordGenerationOptions extends SignatureOptions {
   readonly ttl: number;
 }
 
-interface DnskeyGenerationOptions extends RecordGenerationOptions {
-  readonly additionalDnskeys: readonly DnsRecord[];
-  readonly flags: Partial<DnskeyFlags>;
-}
-
 interface DsGenerationOptions extends RecordGenerationOptions {
   readonly digestType: DigestType;
+}
+
+export interface DnskeyGenerationOptions extends RecordGenerationOptions {
+  readonly additionalDnskeys: readonly DnsRecord[];
+  readonly flags: Partial<DnskeyFlags>;
 }
 
 export class ZoneSigner {


### PR DESCRIPTION
When verification succeeds.

Needed in relaycorp/vera-js#43

- [ ] Consider date period(s) of DS record(s).
- [ ] `dnsseclookUp`: Output intersection with `datePeriod`.